### PR TITLE
ブロック一覧の説明文に任意のメッセージが追加できるように

### DIFF
--- a/View/Helper/BlockIndexHelper.php
+++ b/View/Helper/BlockIndexHelper.php
@@ -87,9 +87,13 @@ class BlockIndexHelper extends AppHelper {
 /**
  * ブロック一覧の画面説明を表示する
  *
+ * @param string $addMsg 追加メッセージ
  * @return string HTML
  */
-	public function description() {
+	public function description($addMsg = '') {
+		if (!empty($addMsg)) {
+			$addMsg = '<br />' . $addMsg;
+		}
 		$message = '<div class="block-index-desc">' .
 			sprintf(
 				__d('blocks', '%sThe highlighted%s target, %s, is currently displayed.'),
@@ -103,6 +107,7 @@ class BlockIndexHelper extends AppHelper {
 					'<span class="glyphicon glyphicon-edit"></span>' .
 				'</button> '
 			) .
+			$addMsg .
 		'</div>';
 		return $this->MessageFlash->description($message);
 	}


### PR DESCRIPTION
ブロック一覧画面に定型の説明書きが出せるdescriptionメソッドに、任意のメッセージを追加することができるようにしています。
