### PR TITLE
マイルームで権限設定でエラーになる不具合修正。（エラーにならないようにしただけ）

### DIFF
--- a/View/Helper/BlockRolePermissionFormHelper.php
+++ b/View/Helper/BlockRolePermissionFormHelper.php
@@ -44,7 +44,7 @@ class BlockRolePermissionFormHelper extends AppHelper {
 
 		$html .= '<div class="form-inline">';
 		foreach ($this->_View->request->data[$model][$permission] as $roleKey => $role) {
-			if (! $role['default'] && $role['fixed']) {
+			if (! $role['default'] && $role['fixed'] || ! Hash::get($role, 'roles_room_id')) {
 				continue;
 			}
 			$html .= $this->__inputBlockRolePermission($model, $permission, $roleKey, $attributes);


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/239

ただし、マイルームなら権限設定のタブを削除した方がよいが、ブロック設定の共通化（ https://github.com/NetCommons3/NetCommons3/issues/160 ）にも関係する話なので、後で対応する。
